### PR TITLE
Remove no longer needed workaround for M1 Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,6 @@ as described [here](docs/run-with-docker.md).
     rm -r polyml-master
     ```
 
-    iii. For M1 Macs you may need to edit the `/usr/local/bin/polyc` script on line line 44 and 46 to remove the quotes otherwise it'll error with `g++ -std=gnu++11: command not found`.
-
-    >        ${LINK} ...
-
-    instead of
-
-    >        "${LINK}" ...
-
 2.  Install and build HOL4
 
     i. Download the source code from the HOL GitHub repository


### PR DESCRIPTION
I followed README.md on an M1 Mac and I realized that a step in README.md is no longer needed. This commit removes the step.

There is a change in polyml that seems to fix the issue https://github.com/polyml/polyml/commit/d5598954999fe26998c6569596ffbc4781fa57a7