### PR TITLE
Add release artefact workflow

### DIFF
--- a/.github/actions/setup-holbuild/action.yml
+++ b/.github/actions/setup-holbuild/action.yml
@@ -19,7 +19,7 @@ runs:
   using: 'composite'
   steps:
     - name: Cache holbuild checkout/build
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       id: cache-holbuild
       with:
         path: ~/holbuild

--- a/.github/actions/setup-polyml/action.yml
+++ b/.github/actions/setup-polyml/action.yml
@@ -23,7 +23,7 @@ runs:
         echo "polyml-rev=$rev" >> "$GITHUB_OUTPUT"
 
     - name: Cache Poly/ML
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       id: cache-polyml
       with:
         path: ~/polyml-install

--- a/.github/workflows/holbuild.yml
+++ b/.github/workflows/holbuild.yml
@@ -14,13 +14,13 @@ concurrency:
 env:
   HOLBUILD_REF: v0.8.1
   HBX_BASENAME: verifereum
-  HBX_ARTIFACT_NAME: verifereum-hbx-${{ github.sha }}
+  HBX_ARTEFACT_NAME: verifereum-hbx-${{ github.sha }}
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: ./.github/actions/setup-polyml
         id: polyml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Restore holbuild global cache
         id: cache-holbuild-global
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@v6
         with:
           path: ~/.cache/holbuild
           key: ${{ steps.cache-key.outputs.build-key }}
@@ -54,7 +54,7 @@ jobs:
         run: holbuild buildhol
 
       - name: Save holbuild toolchain cache after buildhol
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@v6
         continue-on-error: true
         with:
           path: ~/.cache/holbuild
@@ -68,7 +68,7 @@ jobs:
 
       - name: Save holbuild global cache after build
         if: steps.cache-holbuild-global.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@v6
         with:
           path: ~/.cache/holbuild
           key: ${{ steps.cache-key.outputs.build-key }}
@@ -89,10 +89,10 @@ jobs:
             --metadata-out "$archive.json"
           sha256sum "$archive" > "$archive.sha256"
 
-      - name: Upload HBX artifact
-        uses: actions/upload-artifact@v4
+      - name: Upload HBX artefact
+        uses: actions/upload-artifact@v7.0.1
         with:
-          name: ${{ env.HBX_ARTIFACT_NAME }}
+          name: ${{ env.HBX_ARTEFACT_NAME }}
           path: |
             ${{ env.HBX_BASENAME }}.hbx
             ${{ env.HBX_BASENAME }}.hbx.json

--- a/.github/workflows/holbuild.yml
+++ b/.github/workflows/holbuild.yml
@@ -6,7 +6,6 @@ on:
   merge_group:
   push:
     branches: [main]
-    tags: ['v*']
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/holbuild.yml
+++ b/.github/workflows/holbuild.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
   merge_group:
   push:
+    branches: [main]
+    tags: ['v*']
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/holbuild.yml
+++ b/.github/workflows/holbuild.yml
@@ -4,13 +4,16 @@ on:
   workflow_dispatch:
   pull_request:
   merge_group:
+  push:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 env:
-  HOLBUILD_REF: v0.8.0
+  HOLBUILD_REF: v0.8.1
+  HOLBUILD_TARGET: verifereum
+  HBX_ARTIFACT_NAME: verifereum-hbx-${{ github.sha }}
 
 jobs:
   build:
@@ -60,7 +63,7 @@ jobs:
         env:
           TMPDIR: ${{ runner.temp }}
         run: |
-          holbuild --verbose -j"$(nproc)" build --skip-checkpoints --skip-proof-steps
+          holbuild --verbose -j"$(nproc)" build --skip-checkpoints --skip-proof-steps "$HOLBUILD_TARGET"
 
       - name: Save holbuild global cache after build
         if: steps.cache-holbuild-global.outputs.cache-hit != 'true'
@@ -76,3 +79,23 @@ jobs:
             find .holbuild/checkpoints \( -name '*.save' -o -name '*.save.ok' \) 2>/dev/null | head -50 >&2
             exit 1
           fi
+
+      - name: Export HBX archive
+        run: |
+          archive="$HOLBUILD_TARGET.hbx"
+          holbuild export \
+            -o "$archive" \
+            --metadata-out "$archive.json" \
+            "$HOLBUILD_TARGET"
+          sha256sum "$archive" > "$archive.sha256"
+
+      - name: Upload HBX artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.HBX_ARTIFACT_NAME }}
+          path: |
+            ${{ env.HOLBUILD_TARGET }}.hbx
+            ${{ env.HOLBUILD_TARGET }}.hbx.json
+            ${{ env.HOLBUILD_TARGET }}.hbx.sha256
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/holbuild.yml
+++ b/.github/workflows/holbuild.yml
@@ -13,7 +13,7 @@ concurrency:
 
 env:
   HOLBUILD_REF: v0.8.1
-  HOLBUILD_TARGET: verifereum
+  HBX_BASENAME: verifereum
   HBX_ARTIFACT_NAME: verifereum-hbx-${{ github.sha }}
 
 jobs:
@@ -64,7 +64,7 @@ jobs:
         env:
           TMPDIR: ${{ runner.temp }}
         run: |
-          holbuild --verbose -j"$(nproc)" build --skip-checkpoints --skip-proof-steps "$HOLBUILD_TARGET"
+          holbuild --verbose -j"$(nproc)" build --skip-checkpoints --skip-proof-steps
 
       - name: Save holbuild global cache after build
         if: steps.cache-holbuild-global.outputs.cache-hit != 'true'
@@ -83,11 +83,10 @@ jobs:
 
       - name: Export HBX archive
         run: |
-          archive="$HOLBUILD_TARGET.hbx"
+          archive="$HBX_BASENAME.hbx"
           holbuild export \
             -o "$archive" \
-            --metadata-out "$archive.json" \
-            "$HOLBUILD_TARGET"
+            --metadata-out "$archive.json"
           sha256sum "$archive" > "$archive.sha256"
 
       - name: Upload HBX artifact
@@ -95,8 +94,8 @@ jobs:
         with:
           name: ${{ env.HBX_ARTIFACT_NAME }}
           path: |
-            ${{ env.HOLBUILD_TARGET }}.hbx
-            ${{ env.HOLBUILD_TARGET }}.hbx.json
-            ${{ env.HOLBUILD_TARGET }}.hbx.sha256
+            ${{ env.HBX_BASENAME }}.hbx
+            ${{ env.HBX_BASENAME }}.hbx.json
+            ${{ env.HBX_BASENAME }}.hbx.sha256
           if-no-files-found: error
           retention-days: 90

--- a/.github/workflows/holbuild.yml
+++ b/.github/workflows/holbuild.yml
@@ -98,4 +98,4 @@ jobs:
             ${{ env.HOLBUILD_TARGET }}.hbx.json
             ${{ env.HOLBUILD_TARGET }}.hbx.sha256
           if-no-files-found: error
-          retention-days: 30
+          retention-days: 90

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,102 @@
+name: Release artifacts
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing GitHub release tag to build and upload assets for
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.release.tag_name || inputs.release_tag }}
+  cancel-in-progress: false
+
+env:
+  HOLBUILD_REF: v0.8.1
+  HOLBUILD_TARGET: verifereum
+
+jobs:
+  hbx:
+    name: Build holbuild archive
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.release_tag }}
+
+      - uses: ./.github/actions/setup-polyml
+        id: polyml
+
+      - uses: ./.github/actions/setup-holbuild
+        id: holbuild
+        with:
+          holbuild-ref: ${{ env.HOLBUILD_REF }}
+
+      - name: Configure holbuild cache
+        run: echo "HOLBUILD_CACHE=$HOME/.cache/holbuild" >> "$GITHUB_ENV"
+
+      - name: Compute holbuild cache keys
+        id: cache-key
+        run: |
+          toolchain_base="holbuild-v2-toolchain-${{ runner.os }}-${{ steps.polyml.outputs.polyml-rev }}-${{ steps.holbuild.outputs.holbuild-rev }}"
+          build_base="holbuild-v2-release-${{ runner.os }}-${{ steps.polyml.outputs.polyml-rev }}-${{ steps.holbuild.outputs.holbuild-rev }}-${{ hashFiles('holproject.toml', 'holexamples.manifest.toml') }}"
+          echo "toolchain-key=${toolchain_base}" >> "$GITHUB_OUTPUT"
+          echo "build-key=${build_base}" >> "$GITHUB_OUTPUT"
+
+      - name: Restore holbuild global cache
+        id: cache-holbuild-global
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.cache/holbuild
+          key: ${{ steps.cache-key.outputs.build-key }}
+          restore-keys: |
+            ${{ steps.cache-key.outputs.toolchain-key }}
+
+      - name: Build schema-2 HOL toolchain
+        run: holbuild buildhol
+
+      - name: Save holbuild toolchain cache after buildhol
+        uses: actions/cache/save@v5
+        continue-on-error: true
+        with:
+          path: ~/.cache/holbuild
+          key: ${{ steps.cache-key.outputs.toolchain-key }}
+
+      - name: Build project with holbuild
+        env:
+          TMPDIR: ${{ runner.temp }}
+        run: holbuild --verbose -j"$(nproc)" build "$HOLBUILD_TARGET"
+
+      - name: Export HBX archive
+        run: |
+          archive="$HOLBUILD_TARGET.hbx"
+          holbuild export \
+            -o "$archive" \
+            --metadata-out "$archive.json" \
+            "$HOLBUILD_TARGET"
+          sha256sum "$archive" > "$archive.sha256"
+
+      - name: Upload release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
+        run: |
+          archive="$HOLBUILD_TARGET.hbx"
+          gh release upload "$RELEASE_TAG" \
+            "$archive" \
+            "$archive.json" \
+            "$archive.sha256" \
+            --clobber
+
+      - name: Save holbuild global cache after build
+        if: steps.cache-holbuild-global.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: ~/.cache/holbuild
+          key: ${{ steps.cache-key.outputs.build-key }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,12 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: Existing GitHub release tag to build and upload assets for
+        description: Existing GitHub release tag to promote artifacts for
         required: true
         type: string
 
 permissions:
+  actions: read
   contents: write
 
 concurrency:
@@ -18,85 +19,67 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  HOLBUILD_REF: v0.8.1
   HOLBUILD_TARGET: verifereum
+  HOLBUILD_WORKFLOW: holbuild.yml
 
 jobs:
-  hbx:
-    name: Build holbuild archive
+  promote-hbx:
+    name: Promote holbuild archive
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.release.tag_name || inputs.release_tag }}
 
-      - uses: ./.github/actions/setup-polyml
-        id: polyml
-
-      - uses: ./.github/actions/setup-holbuild
-        id: holbuild
-        with:
-          holbuild-ref: ${{ env.HOLBUILD_REF }}
-
-      - name: Configure holbuild cache
-        run: echo "HOLBUILD_CACHE=$HOME/.cache/holbuild" >> "$GITHUB_ENV"
-
-      - name: Compute holbuild cache keys
-        id: cache-key
+      - name: Resolve release ref
         run: |
-          toolchain_base="holbuild-v2-toolchain-${{ runner.os }}-${{ steps.polyml.outputs.polyml-rev }}-${{ steps.holbuild.outputs.holbuild-rev }}"
-          build_base="holbuild-v2-release-${{ runner.os }}-${{ steps.polyml.outputs.polyml-rev }}-${{ steps.holbuild.outputs.holbuild-rev }}-${{ hashFiles('holproject.toml', 'holexamples.manifest.toml') }}"
-          echo "toolchain-key=${toolchain_base}" >> "$GITHUB_OUTPUT"
-          echo "build-key=${build_base}" >> "$GITHUB_OUTPUT"
+          release_tag="${{ github.event.release.tag_name || inputs.release_tag }}"
+          release_sha="$(git rev-parse HEAD)"
+          artifact_name="$HOLBUILD_TARGET-hbx-$release_sha"
 
-      - name: Restore holbuild global cache
-        id: cache-holbuild-global
-        uses: actions/cache/restore@v5
-        with:
-          path: ~/.cache/holbuild
-          key: ${{ steps.cache-key.outputs.build-key }}
-          restore-keys: |
-            ${{ steps.cache-key.outputs.toolchain-key }}
+          echo "RELEASE_TAG=$release_tag" >> "$GITHUB_ENV"
+          echo "RELEASE_SHA=$release_sha" >> "$GITHUB_ENV"
+          echo "HBX_ARTIFACT_NAME=$artifact_name" >> "$GITHUB_ENV"
 
-      - name: Build schema-2 HOL toolchain
-        run: holbuild buildhol
-
-      - name: Save holbuild toolchain cache after buildhol
-        uses: actions/cache/save@v5
-        continue-on-error: true
-        with:
-          path: ~/.cache/holbuild
-          key: ${{ steps.cache-key.outputs.toolchain-key }}
-
-      - name: Build project with holbuild
-        env:
-          TMPDIR: ${{ runner.temp }}
-        run: holbuild --verbose -j"$(nproc)" build "$HOLBUILD_TARGET"
-
-      - name: Export HBX archive
+      - name: Find matching holbuild run
         run: |
-          archive="$HOLBUILD_TARGET.hbx"
-          holbuild export \
-            -o "$archive" \
-            --metadata-out "$archive.json" \
-            "$HOLBUILD_TARGET"
-          sha256sum "$archive" > "$archive.sha256"
+          run_id="$(gh run list \
+            --workflow "$HOLBUILD_WORKFLOW" \
+            --commit "$RELEASE_SHA" \
+            --status success \
+            --json databaseId \
+            --jq '.[0].databaseId // empty')"
+
+          if [ -z "$run_id" ]; then
+            echo "::error::No successful $HOLBUILD_WORKFLOW run found for $RELEASE_SHA. Run holbuild for $RELEASE_TAG, wait for artifact $HBX_ARTIFACT_NAME, then rerun this workflow."
+            exit 1
+          fi
+
+          echo "HOLBUILD_RUN_ID=$run_id" >> "$GITHUB_ENV"
+
+      - name: Download HBX artifact
+        run: |
+          mkdir -p release-assets
+          gh run download "$HOLBUILD_RUN_ID" \
+            --name "$HBX_ARTIFACT_NAME" \
+            --dir release-assets
+
+          archive="release-assets/$HOLBUILD_TARGET.hbx"
+          metadata="$archive.json"
+          checksum="$archive.sha256"
+
+          test -f "$archive"
+          test -f "$metadata"
+          test -f "$checksum"
+          (cd release-assets && sha256sum -c "$HOLBUILD_TARGET.hbx.sha256")
 
       - name: Upload release assets
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
         run: |
-          archive="$HOLBUILD_TARGET.hbx"
+          archive="release-assets/$HOLBUILD_TARGET.hbx"
           gh release upload "$RELEASE_TAG" \
             "$archive" \
             "$archive.json" \
             "$archive.sha256" \
             --clobber
-
-      - name: Save holbuild global cache after build
-        if: steps.cache-holbuild-global.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
-        with:
-          path: ~/.cache/holbuild
-          key: ${{ steps.cache-key.outputs.build-key }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release artifacts
+name: Release artefacts
 
 on:
   release:
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: Existing GitHub release tag to promote artifacts for
+        description: Existing GitHub release tag to promote artefacts for
         required: true
         type: string
 
@@ -29,7 +29,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.release.tag_name || inputs.release_tag }}
 
@@ -37,11 +37,11 @@ jobs:
         run: |
           release_tag="${{ github.event.release.tag_name || inputs.release_tag }}"
           release_sha="$(git rev-parse HEAD)"
-          artifact_name="$HBX_BASENAME-hbx-$release_sha"
+          artefact_name="$HBX_BASENAME-hbx-$release_sha"
 
           echo "RELEASE_TAG=$release_tag" >> "$GITHUB_ENV"
           echo "RELEASE_SHA=$release_sha" >> "$GITHUB_ENV"
-          echo "HBX_ARTIFACT_NAME=$artifact_name" >> "$GITHUB_ENV"
+          echo "HBX_ARTEFACT_NAME=$artefact_name" >> "$GITHUB_ENV"
 
       - name: Find matching holbuild run
         run: |
@@ -53,17 +53,17 @@ jobs:
             --jq '.[0].databaseId // empty')"
 
           if [ -z "$run_id" ]; then
-            echo "::error::No successful $HOLBUILD_WORKFLOW run found for $RELEASE_SHA. Run holbuild for $RELEASE_TAG, wait for artifact $HBX_ARTIFACT_NAME, then rerun this workflow."
+            echo "::error::No successful $HOLBUILD_WORKFLOW run found for $RELEASE_SHA. Run holbuild for $RELEASE_TAG, wait for artefact $HBX_ARTEFACT_NAME, then rerun this workflow."
             exit 1
           fi
 
           echo "HOLBUILD_RUN_ID=$run_id" >> "$GITHUB_ENV"
 
-      - name: Download HBX artifact
+      - name: Download HBX artefact
         run: |
           mkdir -p release-assets
           gh run download "$HOLBUILD_RUN_ID" \
-            --name "$HBX_ARTIFACT_NAME" \
+            --name "$HBX_ARTEFACT_NAME" \
             --dir release-assets
 
           archive="release-assets/$HBX_BASENAME.hbx"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  HOLBUILD_TARGET: verifereum
+  HBX_BASENAME: verifereum
   HOLBUILD_WORKFLOW: holbuild.yml
 
 jobs:
@@ -37,7 +37,7 @@ jobs:
         run: |
           release_tag="${{ github.event.release.tag_name || inputs.release_tag }}"
           release_sha="$(git rev-parse HEAD)"
-          artifact_name="$HOLBUILD_TARGET-hbx-$release_sha"
+          artifact_name="$HBX_BASENAME-hbx-$release_sha"
 
           echo "RELEASE_TAG=$release_tag" >> "$GITHUB_ENV"
           echo "RELEASE_SHA=$release_sha" >> "$GITHUB_ENV"
@@ -66,18 +66,18 @@ jobs:
             --name "$HBX_ARTIFACT_NAME" \
             --dir release-assets
 
-          archive="release-assets/$HOLBUILD_TARGET.hbx"
+          archive="release-assets/$HBX_BASENAME.hbx"
           metadata="$archive.json"
           checksum="$archive.sha256"
 
           test -f "$archive"
           test -f "$metadata"
           test -f "$checksum"
-          (cd release-assets && sha256sum -c "$HOLBUILD_TARGET.hbx.sha256")
+          (cd release-assets && sha256sum -c "$HBX_BASENAME.hbx.sha256")
 
       - name: Upload release assets
         run: |
-          archive="release-assets/$HOLBUILD_TARGET.hbx"
+          archive="release-assets/$HBX_BASENAME.hbx"
           gh release upload "$RELEASE_TAG" \
             "$archive" \
             "$archive.json" \

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ holbuild -j"$(nproc)" build
 
 Plain `Holmake` remains supported as a secondary check when a compatible HOL4 installation is already available, and is also checked in CI.
 
-Release instructions, including the prebuilt holbuild archive artifact, are in [docs/release.md](docs/release.md).
+Release instructions, including the prebuilt holbuild archive artefact, are in [docs/release.md](docs/release.md).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ verifereum/
 
 Verifereum is developed in the [HOL4](https://hol-theorem-prover.org) theorem prover, which is written in Standard ML, and is built with [`holbuild`](https://github.com/charles-cooper/holbuild). The repository's `holproject.toml` is the source of truth for the project configuration and pinned HOL dependencies. The CI workflow (`.github/workflows/holbuild.yml`) is the recommended reference for the exact automated build.
 
-For a local build, install `holbuild` v0.6.0 and run:
+For a local build, install `holbuild` v0.8.1 and run:
 
 ```bash
 holbuild buildhol
@@ -65,6 +65,8 @@ holbuild -j"$(nproc)" build
 `holbuild buildhol` builds and caches the HOL toolchain and dependencies specified by `holproject.toml`.
 
 Plain `Holmake` remains supported as a secondary check when a compatible HOL4 installation is already available, and is also checked in CI.
+
+Release instructions, including the prebuilt holbuild archive artifact, are in [docs/release.md](docs/release.md).
 
 ## Contributing
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -6,11 +6,14 @@ prebuilt holbuild archive for the top-level `verifereum` target.
 ## Maintainer checklist
 
 1. Choose the release version and update `holproject.toml` if needed.
-2. Ensure CI is green for the commit being released.
-3. Create a tag and GitHub Release for that commit, using matching names such as
-   `v0.1.5`.
-4. Publishing the GitHub Release starts `.github/workflows/release.yml`, which
-   uploads:
+2. Ensure the `holbuild` workflow is green for the commit being released. It
+   should have uploaded an artifact named `verifereum-hbx-<commit-sha>`.
+3. Create a tag for that commit, using a name such as `v0.1.5`.
+4. If needed, run the `holbuild` workflow manually for the tag and wait for it
+   to upload `verifereum-hbx-<commit-sha>`.
+5. Create and publish the GitHub Release for the tag.
+6. Publishing the GitHub Release starts `.github/workflows/release.yml`, which
+   promotes the CI artifact to release assets:
 
    ```text
    verifereum.hbx
@@ -19,12 +22,14 @@ prebuilt holbuild archive for the top-level `verifereum` target.
    ```
 
 If the release workflow needs to be rerun, use the `Release artifacts` workflow
-with `workflow_dispatch` and provide the existing release tag.
+with `workflow_dispatch` and provide the existing release tag. The workflow does
+not rebuild the archive; it downloads the matching `holbuild` workflow artifact
+for the release commit and uploads those exact files to the GitHub Release.
 
 ## Manual archive build
 
-The workflow is the preferred release path. To build the same archive locally
-or from another CI system, use holbuild v0.8.1 or newer:
+The CI artifact is the preferred release source. To build the same archive
+locally or from another CI system, use holbuild v0.8.1 or newer:
 
 ```bash
 holbuild buildhol

--- a/docs/release.md
+++ b/docs/release.md
@@ -7,13 +7,13 @@ prebuilt holbuild archive for the project default roots.
 
 1. Choose the release version and update `holproject.toml` if needed.
 2. Ensure the `holbuild` workflow is green for the commit being released. It
-   should have uploaded an artifact named `verifereum-hbx-<commit-sha>`.
+   should have uploaded an artefact named `verifereum-hbx-<commit-sha>`.
 3. Create a tag for that commit, using a name such as `v0.1.5`.
 4. If needed, run the `holbuild` workflow manually for the tag and wait for it
    to upload `verifereum-hbx-<commit-sha>`.
 5. Create and publish the GitHub Release for the tag.
 6. Publishing the GitHub Release starts `.github/workflows/release.yml`, which
-   promotes the CI artifact to release assets:
+   promotes the CI artefact to release assets:
 
    ```text
    verifereum.hbx
@@ -21,16 +21,16 @@ prebuilt holbuild archive for the project default roots.
    verifereum.hbx.sha256
    ```
 
-The CI artifact is retained for 90 days. If the release workflow needs to be
-rerun after the artifact has expired, run the `holbuild` workflow manually for
-the release tag first, then rerun `Release artifacts` with `workflow_dispatch`
+The CI artefact is retained for 90 days. If the release workflow needs to be
+rerun after the artefact has expired, run the `holbuild` workflow manually for
+the release tag first, then rerun `Release artefacts` with `workflow_dispatch`
 and provide the existing release tag. The release workflow does not rebuild the
-archive; it downloads the matching `holbuild` workflow artifact for the release
+archive; it downloads the matching `holbuild` workflow artefact for the release
 commit and uploads those exact files to the GitHub Release.
 
 ## Manual archive build
 
-The CI artifact is the preferred release source. To build the same archive
+The CI artefact is the preferred release source. To build the same archive
 locally or from another CI system, use holbuild v0.8.1 or newer:
 
 ```bash

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,7 +1,7 @@
 # Release process
 
 Verifereum releases are GitHub Releases. Each release should include a
-prebuilt holbuild archive for the top-level `verifereum` target.
+prebuilt holbuild archive for the project default roots.
 
 ## Maintainer checklist
 
@@ -35,11 +35,10 @@ locally or from another CI system, use holbuild v0.8.1 or newer:
 
 ```bash
 holbuild buildhol
-holbuild -j"$(nproc)" build verifereum
+holbuild -j"$(nproc)" build
 holbuild export \
   -o verifereum.hbx \
-  --metadata-out verifereum.hbx.json \
-  verifereum
+  --metadata-out verifereum.hbx.json
 sha256sum verifereum.hbx > verifereum.hbx.sha256
 ```
 
@@ -61,5 +60,5 @@ gh release download vX.Y.Z \
   -p verifereum.hbx.sha256
 sha256sum -c verifereum.hbx.sha256
 holbuild import verifereum.hbx
-holbuild build verifereum
+holbuild build
 ```

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,58 @@
+# Release process
+
+Verifereum releases are GitHub Releases. Each release should include a
+prebuilt holbuild archive for the top-level `verifereum` target.
+
+## Maintainer checklist
+
+1. Choose the release version and update `holproject.toml` if needed.
+2. Ensure CI is green for the commit being released.
+3. Create a tag and GitHub Release for that commit, using matching names such as
+   `v0.1.5`.
+4. Publishing the GitHub Release starts `.github/workflows/release.yml`, which
+   uploads:
+
+   ```text
+   verifereum.hbx
+   verifereum.hbx.json
+   verifereum.hbx.sha256
+   ```
+
+If the release workflow needs to be rerun, use the `Release artifacts` workflow
+with `workflow_dispatch` and provide the existing release tag.
+
+## Manual archive build
+
+The workflow is the preferred release path. To build the same archive locally
+or from another CI system, use holbuild v0.8.1 or newer:
+
+```bash
+holbuild buildhol
+holbuild -j"$(nproc)" build verifereum
+holbuild export \
+  -o verifereum.hbx \
+  --metadata-out verifereum.hbx.json \
+  verifereum
+sha256sum verifereum.hbx > verifereum.hbx.sha256
+```
+
+Upload all three files to the GitHub Release:
+
+```bash
+gh release upload vX.Y.Z \
+  verifereum.hbx \
+  verifereum.hbx.json \
+  verifereum.hbx.sha256
+```
+
+## Consuming a release archive
+
+```bash
+gh release download vX.Y.Z \
+  -p verifereum.hbx \
+  -p verifereum.hbx.json \
+  -p verifereum.hbx.sha256
+sha256sum -c verifereum.hbx.sha256
+holbuild import verifereum.hbx
+holbuild build verifereum
+```

--- a/docs/release.md
+++ b/docs/release.md
@@ -21,10 +21,12 @@ prebuilt holbuild archive for the top-level `verifereum` target.
    verifereum.hbx.sha256
    ```
 
-If the release workflow needs to be rerun, use the `Release artifacts` workflow
-with `workflow_dispatch` and provide the existing release tag. The workflow does
-not rebuild the archive; it downloads the matching `holbuild` workflow artifact
-for the release commit and uploads those exact files to the GitHub Release.
+The CI artifact is retained for 90 days. If the release workflow needs to be
+rerun after the artifact has expired, run the `holbuild` workflow manually for
+the release tag first, then rerun `Release artifacts` with `workflow_dispatch`
+and provide the existing release tag. The release workflow does not rebuild the
+archive; it downloads the matching `holbuild` workflow artifact for the release
+commit and uploads those exact files to the GitHub Release.
 
 ## Manual archive build
 


### PR DESCRIPTION
_co-authored by gpt-5.5_

## Summary

- Add a `Release artefacts` workflow that promotes a CI-produced `verifereum.hbx` archive to a GitHub Release.
- Extend the `holbuild` workflow to build the project default roots, export `verifereum.hbx`, metadata, and checksum, and upload them as a retained workflow artefact.
- Document the release process, including artefact retention and regeneration if the CI artefact expires.

Closes #131

