### PR TITLE
Do not warm addresses for aborted contract creation

### DIFF
--- a/prog/vfmProgScript.sml
+++ b/prog/vfmProgScript.sml
@@ -2772,22 +2772,20 @@ Theorem SPEC_Create_fail:
          addr = (if inst = Create2
                  then address_for_create2 p.callee salt code
                  else address_for_create p.callee sender.nonce) ∧
-         access_check d addr ∧
          LENGTH code ≤ 2 * max_code_size ∧
          gasLeft = p.gasLimit - g - gas ∧
          cappedGas = gasLeft - gasLeft DIV 64 ∧
          ¬p.static ∧
          (sender.balance < value ∨ SUC sender.nonce ≥ 2 ** 64 ∨
           SUC (LENGTH cs) > 1024) ∧
-         access_storage_check d addr ∧
          g + gas + cappedGas ≤ p.gasLimit))
   {(pc,inst)}
   (evm_Stack (b2w F :: DROP (if inst = Create2 then 4 else 3) ss) *
    evm_PC (SUC pc) *
    evm_GasUsed (g + gas) * evm_MsgParams p *
    evm_Exception (INL ()) * evm_ReturnData [] *
-   evm_Rollback (accesses_add addr rb) * evm_Memory em * evm_Contexts cs *
-   evm_Msdomain (msdomain_add_storage addr $ msdomain_add addr d))
+   evm_Rollback rb * evm_Memory em * evm_Contexts cs *
+   evm_Msdomain d)
 Proof
   qmatch_goalsub_abbrev_tac`~_ ∧ djs ∧ _`
   \\ qmatch_goalsub_abbrev_tac`em = _ ∧ is_create ∧ _`
@@ -2931,6 +2929,7 @@ Proof
          fail_def, assert_def, get_current_context_def,
          set_current_context_def, push_stack_def, inc_pc_def,
          inc_pc_or_jump_def]
+  \\ gvs[access_address_split, access_storage_split]
   \\ strip_tac
   \\ conj_tac >- simp[Abbr`cappedGas`,Abbr`gasLeft`]
   \\ conj_tac >-
@@ -3047,6 +3046,7 @@ Proof
          HD_TAKE, proceed_create_def,
          update_accounts_def, get_rollback_def, get_original_def,
          set_original_def, push_context_def, inc_pc_or_jump_def]
+  \\ gvs[access_address_split, access_storage_split]
   \\ strip_tac
   \\ conj_tac >- gvs[Abbr`cappedGas`,Abbr`gasLeft`]
   \\ conj_tac >- (gvs[SUBSET_DEF, PULL_EXISTS,Abbr`all_pcs`,TO_FLOOKUP]

--- a/spec/prop/vfmDecreasesGasScript.sml
+++ b/spec/prop/vfmDecreasesGasScript.sml
@@ -1629,36 +1629,42 @@ Theorem step_create_lemma:
   do
     _ <- set_return_data [];
     sucDepth <- get_num_contexts;
-    _ <- ensure_storage_in_domain v4;
-    if b1 ∨ b2 ∨ sucDepth > 1024 then m1 else if b3 then m2 else
-    proceed_create senderAddress address value code cappedGas
+    if b1 ∨ b2 ∨ sucDepth > 1024 then m1 else do
+      _ <- access_address v4;
+      _ <- ensure_storage_in_domain v4;
+      if b3 then m2 else
+      proceed_create senderAddress address value code cappedGas
+    od
   od = do
     _ <- set_return_data [];
     sucDepth <- get_num_contexts;
-    _ <- ensure_storage_in_domain v4;
-    if b1 ∨ b2 ∨ sucDepth > 1024 then m1 else if b3 then m2 else do
-      _ <- update_accounts $ increment_nonce senderAddress;
-      subContextTx <<- <|
-          from     := senderAddress
-        ; to       := SOME address
-        ; value    := value
-        ; gasLimit := cappedGas
-        ; data     := []
-        (* unused: for concreteness *)
-        ; nonce := 0; gasPrice := 0; accessList := []
-        ; blobVersionedHashes := []
-        ; maxFeePerGas := NONE; maxFeePerBlobGas := NONE
-        ; authorizationList := []
-      |>;
-      rollback <- get_rollback;
-      original <- get_original;
-      set_original $ update_account address empty_account_state original;
-      _ <- update_accounts $
-        transfer_value senderAddress address value o
-        increment_nonce address;
-      _ <- get_static;
-      push_context $
-        (initial_context address code F (Code address) subContextTx, rollback)
+    if b1 ∨ b2 ∨ sucDepth > 1024 then m1 else do
+      _ <- access_address v4;
+      _ <- ensure_storage_in_domain v4;
+      if b3 then m2 else do
+        _ <- update_accounts $ increment_nonce senderAddress;
+        subContextTx <<- <|
+            from     := senderAddress
+          ; to       := SOME address
+          ; value    := value
+          ; gasLimit := cappedGas
+          ; data     := []
+          (* unused: for concreteness *)
+          ; nonce := 0; gasPrice := 0; accessList := []
+          ; blobVersionedHashes := []
+          ; maxFeePerGas := NONE; maxFeePerBlobGas := NONE
+          ; authorizationList := []
+        |>;
+        rollback <- get_rollback;
+        original <- get_original;
+        set_original $ update_account address empty_account_state original;
+        _ <- update_accounts $
+          transfer_value senderAddress address value o
+          increment_nonce address;
+        _ <- get_static;
+        push_context $
+          (initial_context address code F (Code address) subContextTx, rollback)
+      od
     od
   od
 Proof
@@ -1743,7 +1749,6 @@ Proof
   \\ simp[ignore_bind_def]
   \\ irule_at Any decreases_gas_cred_bind_g_0 \\ simp[]
   \\ qpat_abbrev_tac `v4 = COND a b c`
-  \\ irule_at Any decreases_gas_cred_bind_g_0 \\ simp[]
   \\ irule_at Any decreases_gas_cred_bind_g_0 \\ simp[] \\ gen_tac
   \\ simp[GSYM ignore_bind_def]
   \\ irule decreases_gas_cred_consume_gas_debit_more
@@ -1756,9 +1761,10 @@ Proof
   \\ irule_at Any decreases_gas_cred_bind_g_0 \\ simp[]
   \\ irule_at Any decreases_gas_cred_bind_g_0 \\ simp[]
   \\ gen_tac
-  \\ irule_at Any decreases_gas_cred_bind_g_0 \\ simp[]
   \\ IF_CASES_TAC
   >- ( irule decreases_gas_cred_abort_unuse \\ simp[] )
+  \\ irule_at Any decreases_gas_cred_bind_g_0 \\ simp[]
+  \\ irule_at Any decreases_gas_cred_bind_g_0 \\ simp[]
   \\ IF_CASES_TAC
   >- (
     irule decreases_gas_imp \\ rw[]

--- a/spec/prop/vfmDomainSeparationScript.sml
+++ b/spec/prop/vfmDomainSeparationScript.sml
@@ -2438,6 +2438,7 @@ Proof
     \\ gvs[]
     \\ rpt (irule bind_eq \\ simp[] \\ rpt gen_tac \\ strip_tac)
     \\ IF_CASES_TAC \\ simp[]
+    \\ rpt (irule bind_eq \\ simp[] \\ rpt gen_tac \\ strip_tac)
     \\ qmatch_goalsub_abbrev_tac`account_already_created la1`
     \\ qmatch_abbrev_tac`lhs = _`
     \\ qmatch_goalsub_abbrev_tac`account_already_created la2`
@@ -2463,7 +2464,8 @@ Proof
       \\ `toCreate ∈ toSet d.addresses`
       by (
         gvs[access_address_def, return_def, fail_def, CaseEq"prod",
-            CaseEq"bool", fIN_IN, domain_check_def] )
+            CaseEq"bool", CaseEq"domain_mode", fIN_IN, domain_check_def,
+            set_domain_def, bind_def, ignore_bind_def] )
       \\ gs[])
     \\ gs[] )
   \\ gen_tac
@@ -3594,15 +3596,15 @@ Proof
   \\ irule preserves_domain_has_callee_bind \\ simp[] \\ gen_tac
   \\ irule preserves_domain_has_callee_ignore_bind \\ simp[]
   \\ simp[ignore_bind_def]
-  \\ irule preserves_domain_has_callee_access_address_bind \\ simp[]
   \\ irule preserves_domain_has_callee_bind \\ simp[] \\ gen_tac
   \\ irule preserves_domain_has_callee_bind \\ simp[]
   \\ irule preserves_domain_has_callee_bind \\ simp[]
   \\ irule preserves_domain_has_callee_bind \\ simp[]
   \\ irule preserves_domain_has_callee_bind \\ simp[] \\ gen_tac
-  \\ irule preserves_domain_has_callee_bind \\ simp[]
-  \\ qpat_abbrev_tac`b0 = COND _ _ _`
+  \\ qpat_abbrev_tac`address = COND x _ _`
   \\ IF_CASES_TAC >- rw[]
+  \\ irule preserves_domain_has_callee_access_address_bind \\ simp[]
+  \\ irule preserves_domain_has_callee_bind \\ simp[]
   \\ IF_CASES_TAC >- rw[]
   \\ irule preserves_domain_has_callee_proceed_create
   \\ rw[]
@@ -3615,6 +3617,7 @@ Theorem step_inst_preserves_domain_has_callee[simp]:
 Proof
   Cases_on`op` \\ rw[step_inst_def]
   \\ TRY (irule preserves_domain_has_callee_ignore_bind \\ rw[])
+  \\ TRY (irule preserves_domain_has_callee_step_create \\ rw[])
   \\ TRY (irule preserves_domain_has_callee_step_copy_to_memory \\ rw[])
 QED
 

--- a/spec/prop/vfmExecutionPropScript.sml
+++ b/spec/prop/vfmExecutionPropScript.sml
@@ -2281,15 +2281,6 @@ Proof
   >- ( irule preserves_wf_accounts_imp_pred \\ rw[] )
   \\ qexists_tac`λs. accounts = s.rollback.accounts`
   \\ reverse conj_tac
-  >- (
-    rw[access_address_def, return_def, fail_def, domain_check_def]
-    \\ Cases_on`s.msdomain` \\ gs[]
-    \\ rw[set_domain_def, bind_def, ignore_bind_def, return_def] )
-  \\ irule preserves_wf_accounts_pred_pred_bind \\ simp[]
-  \\ reverse conj_tac
-  >- ( irule preserves_wf_accounts_imp_pred \\ rw[] )
-  \\ qexists_tac`λs. accounts = s.rollback.accounts`
-  \\ reverse conj_tac
   >- rw[get_gas_left_def, return_def, get_current_context_def,
         bind_def, fail_def]
   \\ gen_tac
@@ -2327,6 +2318,18 @@ Proof
     rw[get_num_contexts_def, return_def, get_current_context_def, ignore_bind_def,
        bind_def, fail_def, assert_def, set_current_context_def, get_static_def])
   \\ gen_tac
+  \\ IF_CASES_TAC
+  >- ( irule preserves_wf_accounts_imp_pred \\ rw[] )
+  \\ simp[ignore_bind_def]
+  \\ irule preserves_wf_accounts_pred_pred_bind \\ simp[]
+  \\ reverse conj_tac
+  >- ( irule preserves_wf_accounts_imp_pred \\ rw[] )
+  \\ qexists_tac`λs. accounts = s.rollback.accounts`
+  \\ reverse conj_tac
+  >- (
+    rw[access_address_def, return_def, fail_def, domain_check_def]
+    \\ Cases_on`s.msdomain` \\ gs[]
+    \\ rw[set_domain_def, bind_def, ignore_bind_def, return_def] )
   \\ irule preserves_wf_accounts_pred_pred_bind \\ simp[]
   \\ reverse conj_tac
   >- ( irule preserves_wf_accounts_imp_pred \\ rw[] )
@@ -2336,8 +2339,6 @@ Proof
     rw[ensure_storage_in_domain_def, return_def, ignore_bind_def,
        bind_def, fail_def, assert_def, get_static_def, domain_check_def]
     \\ Cases_on`s.msdomain` \\ gs defs \\ rw[])
-  \\ IF_CASES_TAC
-  >- ( irule preserves_wf_accounts_imp_pred \\ rw[] )
   \\ IF_CASES_TAC
   >- (
     simp[abort_create_exists_def]
@@ -3308,7 +3309,6 @@ Proof
   \\ irule limits_num_contexts_bind \\ qexists_tac`n` \\ simp[] \\ gen_tac
   \\ irule limits_num_contexts_bind \\ qexists_tac`n` \\ simp[] \\ gen_tac
   \\ irule limits_num_contexts_ignore_bind \\ qexists_tac`n` \\ simp[]
-  \\ irule limits_num_contexts_ignore_bind \\ qexists_tac`n` \\ simp[]
   \\ irule limits_num_contexts_bind \\ qexists_tac`n` \\ simp[] \\ gen_tac
   \\ irule limits_num_contexts_ignore_bind \\ qexists_tac`n` \\ simp[]
   \\ irule limits_num_contexts_ignore_bind \\ qexists_tac`n` \\ simp[]
@@ -3324,8 +3324,6 @@ Proof
   >- (
     irule limits_num_contexts_mono \\ qexistsl_tac[`n`,`n`] \\ simp[]
     \\ tac )
-  \\ simp[limits_num_contexts_reorder_ensure_storage]
-  \\ irule limits_num_contexts_ignore_bind \\ qexists_tac`n` \\ simp[]
   \\ irule limits_num_contexts_check
   \\ reverse conj_tac
   >- (
@@ -3336,6 +3334,8 @@ Proof
   \\ simp[Abbr`b4`]
   \\ `SUC n1 ≤ n` by gs[]
   \\ `n ≤ MIN (SUC n) 1026` by gs[]
+  \\ irule limits_num_contexts_ignore_bind \\ qexists_tac`SUC n1` \\ simp[]
+  \\ irule limits_num_contexts_ignore_bind \\ qexists_tac`SUC n1` \\ simp[]
   \\ IF_CASES_TAC
   >- (
     irule limits_num_contexts_mono

--- a/spec/prop/vfmJumpDestScript.sml
+++ b/spec/prop/vfmJumpDestScript.sml
@@ -1667,6 +1667,14 @@ Proof
   drule bind_preserves_jumpDest_NONE_imp >> simp[] >>
   disch_then irule >> qpat_x_assum`_ = (_,_)`kall_tac >>
   rpt gen_tac >> strip_tac >>
+  gvs[COND_RATOR] >>
+  qpat_x_assum`_ = (_,_)`mp_tac >>
+  IF_CASES_TAC >- (
+    strip_tac >>
+    drule(REWRITE_RULE[preserves_jumpDest_def]
+            preserves_jumpDest_abort_unuse) >>
+    rw[] ) >>
+  strip_tac >>
   drule bind_preserves_jumpDest_NONE_imp >> simp[] >>
   disch_then irule >> qpat_x_assum`_ = (_,_)`kall_tac >>
   rpt gen_tac >> strip_tac >>
@@ -1675,11 +1683,6 @@ Proof
   rpt gen_tac >> strip_tac >>
   gvs[COND_RATOR] >>
   qpat_x_assum`_ = (_,_)`mp_tac >>
-  IF_CASES_TAC >- (
-    strip_tac >>
-    drule(REWRITE_RULE[preserves_jumpDest_def]
-            preserves_jumpDest_abort_unuse) >>
-    rw[] ) >>
   IF_CASES_TAC >- (
     strip_tac >>
     drule(REWRITE_RULE[preserves_jumpDest_def]

--- a/spec/prop/vfmRunCallScript.sml
+++ b/spec/prop/vfmRunCallScript.sml
@@ -421,12 +421,12 @@ Proof
   >> irule preserves_pushed_rb_storage_bind >> simp[] >> gen_tac
   >> irule preserves_pushed_rb_storage_bind >> simp[] >> gen_tac
   >> irule preserves_pushed_rb_storage_ignore_bind >> simp[]
-  >> irule preserves_pushed_rb_storage_ignore_bind >> simp[]
   >> irule preserves_pushed_rb_storage_bind >> simp[] >> gen_tac
   >> rpt (irule preserves_pushed_rb_storage_ignore_bind >> simp[])
   >> irule preserves_pushed_rb_storage_bind >> simp[] >> gen_tac
-  >> rpt (irule preserves_pushed_rb_storage_ignore_bind >> simp[])
   >> irule preserves_pushed_rb_storage_cond >> simp[]
+  >> irule preserves_pushed_rb_storage_ignore_bind >> simp[]
+  >> irule preserves_pushed_rb_storage_ignore_bind >> simp[]
   >> irule preserves_pushed_rb_storage_cond >> simp[]
 QED
 

--- a/spec/prop/vfmRunCallScript.sml
+++ b/spec/prop/vfmRunCallScript.sml
@@ -668,42 +668,52 @@ Proof
   >> `same_frame_rel s s8` by metis_tac[same_frame_rel_trans]
   >> `s8.contexts ≠ [] ∧ LENGTH s8.contexts = LENGTH s.contexts`
   by (rpt strip_tac >> gvs[same_frame_rel_def])
-  (* Peel access_address *)
+  (* Peel get_gas_left *)
   >> drule_at (Pat`bind`) bind_psf_grows_extract
   >> simp[] >> qpat_x_assum`_ _ = (_,_)`kall_tac >> strip_tac >> gvs[]
   >> rename1`same_frame_rel s8 s9`
   >> `same_frame_rel s s9` by metis_tac[same_frame_rel_trans]
   >> `s9.contexts ≠ [] ∧ LENGTH s9.contexts = LENGTH s.contexts`
   by (rpt strip_tac >> gvs[same_frame_rel_def])
-  (* Peel get_gas_left *)
+  (* Peel consume_gas (cappedGas) *)
   >> drule_at (Pat`bind`) bind_psf_grows_extract
   >> simp[] >> qpat_x_assum`_ _ = (_,_)`kall_tac >> strip_tac >> gvs[]
   >> rename1`same_frame_rel s9 s0`
   >> `same_frame_rel s s0` by metis_tac[same_frame_rel_trans]
   >> `s0.contexts ≠ [] ∧ LENGTH s0.contexts = LENGTH s.contexts`
   by (rpt strip_tac >> gvs[same_frame_rel_def])
-  (* Peel consume_gas (cappedGas) *)
+  (* Peel assert_not_static *)
   >> drule_at (Pat`bind`) bind_psf_grows_extract
   >> simp[] >> qpat_x_assum`_ _ = (_,_)`kall_tac >> strip_tac >> gvs[]
   >> rename1`same_frame_rel s0 sa`
   >> `same_frame_rel s sa` by metis_tac[same_frame_rel_trans]
   >> `sa.contexts ≠ [] ∧ LENGTH sa.contexts = LENGTH s.contexts`
   by (rpt strip_tac >> gvs[same_frame_rel_def])
-  (* Peel assert_not_static *)
+  (* Peel set_return_data *)
   >> drule_at (Pat`bind`) bind_psf_grows_extract
   >> simp[] >> qpat_x_assum`_ _ = (_,_)`kall_tac >> strip_tac >> gvs[]
   >> rename1`same_frame_rel sa sb`
   >> `same_frame_rel s sb` by metis_tac[same_frame_rel_trans]
   >> `sb.contexts ≠ [] ∧ LENGTH sb.contexts = LENGTH s.contexts`
   by (rpt strip_tac >> gvs[same_frame_rel_def])
-  (* Peel set_return_data *)
+  (* Peel get_num_contexts *)
   >> drule_at (Pat`bind`) bind_psf_grows_extract
   >> simp[] >> qpat_x_assum`_ _ = (_,_)`kall_tac >> strip_tac >> gvs[]
   >> rename1`same_frame_rel sb sc`
   >> `same_frame_rel s sc` by metis_tac[same_frame_rel_trans]
   >> `sc.contexts ≠ [] ∧ LENGTH sc.contexts = LENGTH s.contexts`
   by (rpt strip_tac >> gvs[same_frame_rel_def])
-  (* Peel get_num_contexts *)
+  (* Split the preliminary failure condition. *)
+  >> gvs[COND_RATOR]
+  >> qmatch_asmsub_abbrev_tac`COND preliminaryFailure _ _ = (_, _)`
+  >> qpat_x_assum`COND preliminaryFailure _ _ = _`mp_tac
+  >> IF_CASES_TAC
+  >- ((* abort_unuse: preserves_same_frame, can't grow *)
+      strip_tac >>
+      drule_at (Pat`_ = (_, s')`) psf_imp_length_contexts_preserved
+      >> simp[])
+  >> strip_tac
+  (* Peel access_address *)
   >> drule_at (Pat`bind`) bind_psf_grows_extract
   >> simp[] >> qpat_x_assum`_ _ = (_,_)`kall_tac >> strip_tac >> gvs[]
   >> rename1`same_frame_rel sc sd`
@@ -717,15 +727,10 @@ Proof
   >> `same_frame_rel s se` by metis_tac[same_frame_rel_trans]
   >> `se.contexts ≠ [] ∧ LENGTH se.contexts = LENGTH s.contexts`
   by (rpt strip_tac >> gvs[same_frame_rel_def])
-  (* Now at the conditional *)
-  >> gvs[Ntimes COND_RATOR 2]
+  (* Now at the collision conditional. *)
+  >> gvs[COND_RATOR]
   >> qmatch_asmsub_abbrev_tac`COND bbb _ _ = (_, _)`
   >> qpat_x_assum`COND bbb _ _ = _`mp_tac
-  >> IF_CASES_TAC
-  >- ((* abort_unuse: preserves_same_frame, can't grow *)
-      strip_tac >>
-      drule_at (Pat`_ = (_, s')`) psf_imp_length_contexts_preserved
-      >> simp[])
   >> IF_CASES_TAC
   >- ((* abort_create_exists: length_preserves, can't grow *)
       strip_tac >>
@@ -1362,20 +1367,12 @@ Proof
     >> `s8.contexts ≠ [] ∧ LENGTH s8.contexts = LENGTH s7.contexts`
          by (rpt strip_tac >> gvs[same_frame_rel_def])
     >> `LENGTH (FST (HD s8.contexts)).stack < stack_limit` by gvs[]
-    (* Peel access_address *)
-    >> drule_at (Pat`bind`) bind_psf_phs_grows_extract
-    >> simp[] >> qpat_x_assum`_ _ = (_,_)`kall_tac
-    >> strip_tac >> gvs[]
-    >> rename1`same_frame_rel s8 s9`
-    >> `s9.contexts ≠ [] ∧ LENGTH s9.contexts = LENGTH s8.contexts`
-         by (rpt strip_tac >> gvs[same_frame_rel_def])
-    >> `LENGTH (FST (HD s9.contexts)).stack < stack_limit` by gvs[]
     (* Peel get_gas_left *)
     >> drule_at (Pat`bind`) bind_psf_phs_grows_extract
     >> simp[] >> qpat_x_assum`_ _ = (_,_)`kall_tac
     >> strip_tac >> gvs[]
-    >> rename1`same_frame_rel s9 s0`
-    >> `s0.contexts ≠ [] ∧ LENGTH s0.contexts = LENGTH s9.contexts`
+    >> rename1`same_frame_rel s8 s0`
+    >> `s0.contexts ≠ [] ∧ LENGTH s0.contexts = LENGTH s8.contexts`
          by (rpt strip_tac >> gvs[same_frame_rel_def])
     >> `LENGTH (FST (HD s0.contexts)).stack < stack_limit` by gvs[]
     (* Peel consume_gas (cappedGas) *)
@@ -1410,19 +1407,32 @@ Proof
     >> `sd.contexts ≠ [] ∧ LENGTH sd.contexts = LENGTH sc.contexts`
          by (rpt strip_tac >> gvs[same_frame_rel_def])
     >> `LENGTH (FST (HD sd.contexts)).stack < stack_limit` by gvs[]
+    (* Split the preliminary failure condition. *)
+    >> gvs[COND_RATOR]
+    >> qmatch_asmsub_abbrev_tac`COND preliminaryFailure _ _ = (_, _)`
+    >> qpat_x_assum`COND preliminaryFailure _ _ = _`mp_tac
+    >> IF_CASES_TAC
+    >- (strip_tac >> drule_at (Pat`_ = (_, s')`) psf_imp_length_contexts_preserved >> simp[])
+    >> strip_tac
+    (* Peel access_address *)
+    >> drule_at (Pat`bind`) bind_psf_phs_grows_extract
+    >> simp[] >> qpat_x_assum`_ _ = (_,_)`kall_tac
+    >> strip_tac >> gvs[]
+    >> rename1`same_frame_rel sd sx`
+    >> `sx.contexts ≠ [] ∧ LENGTH sx.contexts = LENGTH sd.contexts`
+         by (rpt strip_tac >> gvs[same_frame_rel_def])
+    >> `LENGTH (FST (HD sx.contexts)).stack < stack_limit` by gvs[]
     (* Peel ensure_storage_in_domain *)
     >> drule_at (Pat`bind`) bind_psf_phs_grows_extract
     >> simp[] >> qpat_x_assum`_ _ = (_,_)`kall_tac
     >> strip_tac >> gvs[]
-    >> rename1`same_frame_rel sd se`
-    >> `se.contexts ≠ [] ∧ LENGTH se.contexts = LENGTH sd.contexts`
+    >> rename1`same_frame_rel sx se`
+    >> `se.contexts ≠ [] ∧ LENGTH se.contexts = LENGTH sx.contexts`
          by (rpt strip_tac >> gvs[same_frame_rel_def])
     >> `LENGTH (FST (HD se.contexts)).stack < stack_limit` by gvs[]
-    >> gvs[Ntimes COND_RATOR 2]
+    >> gvs[COND_RATOR]
     >> qmatch_asmsub_abbrev_tac`COND bbb _ _ = (_, _)`
     >> qpat_x_assum`COND bbb _ _ = _`mp_tac
-    >> IF_CASES_TAC
-    >- (strip_tac >> drule_at (Pat`_ = (_, s')`) psf_imp_length_contexts_preserved >> simp[])
     >> IF_CASES_TAC
     >- (strip_tac >> drule (REWRITE_RULE[length_preserves_def] length_preserves_abort_create_exists) >> simp[])
     >> strip_tac
@@ -1650,20 +1660,12 @@ Proof
     >> `s8.contexts ≠ [] ∧ LENGTH s8.contexts = LENGTH s7.contexts`
          by (rpt strip_tac >> gvs[same_frame_rel_def])
     >> `(FST (HD s.contexts)).gasUsed ≤ (FST (HD s8.contexts)).gasUsed` by decide_tac
-    (* access_address *)
-    >> drule_at (Pat`bind`) bind_psf_phgm_grows_extract
-    >> simp[] >> qpat_x_assum`_ _ = (_,_)`kall_tac
-    >> strip_tac >> gvs[]
-    >> rename1`same_frame_rel s8 s9`
-    >> `s9.contexts ≠ [] ∧ LENGTH s9.contexts = LENGTH s8.contexts`
-         by (rpt strip_tac >> gvs[same_frame_rel_def])
-    >> `(FST (HD s.contexts)).gasUsed ≤ (FST (HD s9.contexts)).gasUsed` by decide_tac
     (* get_gas_left *)
     >> drule_at (Pat`bind`) bind_psf_phgm_grows_extract
     >> simp[] >> qpat_x_assum`_ _ = (_,_)`kall_tac
     >> strip_tac >> gvs[]
-    >> rename1`same_frame_rel s9 s0`
-    >> `s0.contexts ≠ [] ∧ LENGTH s0.contexts = LENGTH s9.contexts`
+    >> rename1`same_frame_rel s8 s0`
+    >> `s0.contexts ≠ [] ∧ LENGTH s0.contexts = LENGTH s8.contexts`
          by (rpt strip_tac >> gvs[same_frame_rel_def])
     >> `(FST (HD s.contexts)).gasUsed ≤ (FST (HD s0.contexts)).gasUsed` by decide_tac
     (* consume_gas cappedGas *)
@@ -1698,19 +1700,32 @@ Proof
     >> `sd.contexts ≠ [] ∧ LENGTH sd.contexts = LENGTH sc.contexts`
          by (rpt strip_tac >> gvs[same_frame_rel_def])
     >> `(FST (HD s.contexts)).gasUsed ≤ (FST (HD sd.contexts)).gasUsed` by decide_tac
+    (* Split the preliminary failure condition. *)
+    >> gvs[COND_RATOR]
+    >> qmatch_asmsub_abbrev_tac`COND preliminaryFailure _ _ = (_, _)`
+    >> qpat_x_assum`COND preliminaryFailure _ _ = _`mp_tac
+    >> IF_CASES_TAC
+    >- (strip_tac >> drule_at (Pat`_ = (_, s')`) psf_imp_length_contexts_preserved >> simp[])
+    >> strip_tac
+    (* access_address *)
+    >> drule_at (Pat`bind`) bind_psf_phgm_grows_extract
+    >> simp[] >> qpat_x_assum`_ _ = (_,_)`kall_tac
+    >> strip_tac >> gvs[]
+    >> rename1`same_frame_rel sd sx`
+    >> `sx.contexts ≠ [] ∧ LENGTH sx.contexts = LENGTH sd.contexts`
+         by (rpt strip_tac >> gvs[same_frame_rel_def])
+    >> `(FST (HD s.contexts)).gasUsed ≤ (FST (HD sx.contexts)).gasUsed` by decide_tac
     (* ensure_storage_in_domain *)
     >> drule_at (Pat`bind`) bind_psf_phgm_grows_extract
     >> simp[] >> qpat_x_assum`_ _ = (_,_)`kall_tac
     >> strip_tac >> gvs[]
-    >> rename1`same_frame_rel sd se`
-    >> `se.contexts ≠ [] ∧ LENGTH se.contexts = LENGTH sd.contexts`
+    >> rename1`same_frame_rel sx se`
+    >> `se.contexts ≠ [] ∧ LENGTH se.contexts = LENGTH sx.contexts`
          by (rpt strip_tac >> gvs[same_frame_rel_def])
     >> `(FST (HD s.contexts)).gasUsed ≤ (FST (HD se.contexts)).gasUsed` by decide_tac
-    >> gvs[Ntimes COND_RATOR 2]
+    >> gvs[COND_RATOR]
     >> qmatch_asmsub_abbrev_tac`COND bbb _ _ = (_, _)`
     >> qpat_x_assum`COND bbb _ _ = _`mp_tac
-    >> IF_CASES_TAC
-    >- (strip_tac >> drule_at (Pat`_ = (_, s')`) psf_imp_length_contexts_preserved >> simp[])
     >> IF_CASES_TAC
     >- (strip_tac >> drule (REWRITE_RULE[length_preserves_def] length_preserves_abort_create_exists) >> simp[])
     >> strip_tac
@@ -2038,19 +2053,12 @@ Proof
     >> rename1`same_frame_rel s7 s8`
     >> `s8.contexts ≠ [] ∧ LENGTH s8.contexts = LENGTH s7.contexts`
          by (rpt strip_tac >> gvs[same_frame_rel_def])
-    (* access_address *)
-    >> drule_at (Pat`bind`) bind_psf_phgm_grows_extract
-    >> simp[] >> qpat_x_assum`_ _ = (_,_)`kall_tac
-    >> strip_tac >> gvs[]
-    >> rename1`same_frame_rel s8 s9`
-    >> `s9.contexts ≠ [] ∧ LENGTH s9.contexts = LENGTH s8.contexts`
-         by (rpt strip_tac >> gvs[same_frame_rel_def])
     (* get_gas_left *)
     >> drule_at (Pat`bind`) bind_psf_phgm_grows_extract
     >> simp[] >> qpat_x_assum`_ _ = (_,_)`kall_tac
     >> strip_tac >> gvs[]
-    >> rename1`same_frame_rel s9 s0`
-    >> `s0.contexts ≠ [] ∧ LENGTH s0.contexts = LENGTH s9.contexts`
+    >> rename1`same_frame_rel s8 s0`
+    >> `s0.contexts ≠ [] ∧ LENGTH s0.contexts = LENGTH s8.contexts`
          by (rpt strip_tac >> gvs[same_frame_rel_def])
     (* consume_gas cappedGas: this is the key additive-reservation point. *)
     >> drule_at (Pat`bind`) bind_psf_phgm_grows_extract
@@ -2085,18 +2093,30 @@ Proof
     >> rename1`same_frame_rel sc sd`
     >> `sd.contexts ≠ [] ∧ LENGTH sd.contexts = LENGTH sc.contexts`
          by (rpt strip_tac >> gvs[same_frame_rel_def])
+    (* Split the preliminary failure condition. *)
+    >> gvs[COND_RATOR]
+    >> qmatch_asmsub_abbrev_tac`COND preliminaryFailure _ _ = (_, _)`
+    >> qpat_x_assum`COND preliminaryFailure _ _ = _`mp_tac
+    >> IF_CASES_TAC
+    >- (strip_tac >> drule_at (Pat`_ = (_, s')`) psf_imp_length_contexts_preserved >> simp[])
+    >> strip_tac
+    (* access_address *)
+    >> drule_at (Pat`bind`) bind_psf_phgm_grows_extract
+    >> simp[] >> qpat_x_assum`_ _ = (_,_)`kall_tac
+    >> strip_tac >> gvs[]
+    >> rename1`same_frame_rel sd sx`
+    >> `sx.contexts ≠ [] ∧ LENGTH sx.contexts = LENGTH sd.contexts`
+         by (rpt strip_tac >> gvs[same_frame_rel_def])
     (* ensure_storage_in_domain *)
     >> drule_at (Pat`bind`) bind_psf_phgm_grows_extract
     >> simp[] >> qpat_x_assum`_ _ = (_,_)`kall_tac
     >> strip_tac >> gvs[]
-    >> rename1`same_frame_rel sd se`
-    >> `se.contexts ≠ [] ∧ LENGTH se.contexts = LENGTH sd.contexts`
+    >> rename1`same_frame_rel sx se`
+    >> `se.contexts ≠ [] ∧ LENGTH se.contexts = LENGTH sx.contexts`
          by (rpt strip_tac >> gvs[same_frame_rel_def])
-    >> gvs[Ntimes COND_RATOR 2]
+    >> gvs[COND_RATOR]
     >> qmatch_asmsub_abbrev_tac`COND bbb _ _ = (_, _)`
     >> qpat_x_assum`COND bbb _ _ = _`mp_tac
-    >> IF_CASES_TAC
-    >- (strip_tac >> drule_at (Pat`_ = (_, s')`) psf_imp_length_contexts_preserved >> simp[])
     >> IF_CASES_TAC
     >- (strip_tac >> drule (REWRITE_RULE[length_preserves_def] length_preserves_abort_create_exists) >> simp[])
     >> strip_tac

--- a/spec/prop/vfmStepLengthScript.sml
+++ b/spec/prop/vfmStepLengthScript.sml
@@ -363,16 +363,6 @@ Proof
   >> irule psf_or_grow_ignore_bind >> simp[]
   >> qexists_tac `pco` >> simp[]
   >> conj_tac >- simp[assert_def]
-  >> irule psf_or_grow_ignore_bind >> simp[]
-  >> qexists_tac `pco` >> simp[]
-  >> conj_tac >- (
-    rpt strip_tac
-    >> qmatch_asmsub_abbrev_tac`access_address addr`
-    >> `preserves_same_frame (access_address addr)` by simp[]
-    >> pop_assum mp_tac >> rewrite_tac[preserves_same_frame_def]
-    >> disch_then drule >> rw[]
-    >> drule same_frame_rel_callee
-    >> gvs[Abbr`pco`])
   >> irule psf_or_grow_bind >> simp[] >>
   qexists_tac `λx s. pco s` >> simp[] >>
   conj_tac
@@ -424,6 +414,20 @@ Proof
     >> drule same_frame_rel_callee
     >> gvs[Abbr`pco`])
   >> gen_tac
+  >> irule psf_or_grow_cond >> conj_tac
+  >- (
+    (* abort_unuse branch: preserves_same_frame, trivially psf_or_grow *)
+    simp[])
+  >> irule psf_or_grow_ignore_bind >> simp[]
+  >> qexists_tac `pco` >> simp[]
+  >> conj_tac >- (
+    rpt strip_tac
+    >> qmatch_asmsub_abbrev_tac`access_address addr`
+    >> `preserves_same_frame (access_address addr)` by simp[]
+    >> pop_assum mp_tac >> rewrite_tac[preserves_same_frame_def]
+    >> disch_then drule >> rw[]
+    >> drule same_frame_rel_callee
+    >> gvs[Abbr`pco`])
   >> irule psf_or_grow_ignore_bind >> simp[] >>
   qexists_tac `pco` >> simp[]
   >> conj_tac
@@ -435,10 +439,6 @@ Proof
     >> disch_then drule >> rw[]
     >> drule same_frame_rel_callee
     >> gvs[Abbr`pco`])
-  >> irule psf_or_grow_cond >> conj_tac
-  >- (
-    (* abort_unuse branch: preserves_same_frame, trivially psf_or_grow *)
-    simp[])
   >> irule psf_or_grow_cond >> conj_tac
   >- (
     (* abort_create_exists senderAddress: where senderAddress = head's callee *)
@@ -471,7 +471,8 @@ Theorem step_create_same_frame:
 Proof
   strip_tac
   >> `s.contexts ≠ []` by gvs[outputTo_consistent_def]
-  >> `same_frame_or_grow (step_create two)` by simp[]
+  >> `same_frame_or_grow (step_create two)` by
+       irule same_frame_or_grow_step_create
   >> pop_assum mp_tac >> rewrite_tac[same_frame_or_grow_def]
   >> disch_then drule >> rw[]
 QED
@@ -1033,17 +1034,18 @@ Proof
   drule_at(Pat`bind`)bind_length_preserves_imp_grow >>
   disch_then irule >> simp[] >>
   qpat_x_assum`_ = (_,_)`kall_tac >> rpt gen_tac >> strip_tac >>
-  drule_at(Pat`bind`)bind_length_preserves_imp_grow >>
-  disch_then irule >> simp[] >>
-  qpat_x_assum`_ = (_,_)`kall_tac >> rpt gen_tac >> strip_tac >>
-  drule_at(Pat`bind`)bind_length_preserves_imp_grow >>
-  disch_then irule >> simp[] >>
-  qpat_x_assum`_ = (_,_)`kall_tac >> rpt gen_tac >> strip_tac >>
   gvs[COND_RATOR,CaseEq"bool"]
   (* abort_unuse path: preserves_same_frame, can't grow *)
   >> TRY (
     drule_at(Pat`_ = (_,_)`)psf_imp_length_contexts_preserved >>
     simp[] >> NO_TAC ) >>
+  drule_at(Pat`bind`)bind_length_preserves_imp_grow >>
+  disch_then irule >> simp[] >>
+  qpat_x_assum`_ = (_,_)`kall_tac >> rpt gen_tac >> strip_tac >>
+  drule_at(Pat`bind`)bind_length_preserves_imp_grow >>
+  disch_then irule >> simp[] >>
+  qpat_x_assum`_ = (_,_)`kall_tac >> rpt gen_tac >> strip_tac >>
+  gvs[COND_RATOR,CaseEq"bool"] >>
   TRY (
     drule(REWRITE_RULE[length_preserves_def]
       length_preserves_abort_create_exists) >> gvs[] >> NO_TAC) >>

--- a/spec/prop/vfmStoragePredicatesScript.sml
+++ b/spec/prop/vfmStoragePredicatesScript.sml
@@ -1561,9 +1561,12 @@ Proof
   irule preserves_storage_bind >> simp[] >> gen_tac >>
   irule preserves_storage_bind >> simp[] >> gen_tac >>
   irule preserves_storage_ignore_bind >> simp[] >>
+  irule preserves_storage_bind >> simp[] >> gen_tac >>
+  irule preserves_storage_ignore_bind >> simp[] >>
+  irule preserves_storage_ignore_bind >> simp[] >>
   irule preserves_storage_ignore_bind >> simp[] >>
   irule preserves_storage_bind >> simp[] >> gen_tac >>
-  rpt(irule preserves_storage_ignore_bind >> simp[])
+  irule preserves_storage_cond >> simp[]
 QED
 
 Theorem step_call_same_frame_preserves_storage:

--- a/spec/vfmExecutionScript.sml
+++ b/spec/vfmExecutionScript.sml
@@ -1134,22 +1134,24 @@ Definition step_create_def:
                 then address_for_create2 senderAddress salt code
                 else address_for_create senderAddress nonce;
     assert (LENGTH code ≤ 2 * max_code_size) OutOfGas;
-    access_address address;
     gasLeft <- get_gas_left;
     cappedGas <<- gasLeft - gasLeft DIV 64;
     consume_gas cappedGas;
     assert_not_static;
     set_return_data [];
     sucDepth <- get_num_contexts;
-    ensure_storage_in_domain address;
-    toCreate <<- lookup_account address accounts;
     if sender.balance < value ∨
        SUC nonce ≥ 2 ** 64 ∨
        sucDepth > 1024
     then abort_unuse cappedGas
-    else if account_already_created toCreate
-    then abort_create_exists senderAddress
-    else proceed_create senderAddress address value code cappedGas
+    else do
+      access_address address;
+      ensure_storage_in_domain address;
+      toCreate <<- lookup_account address accounts;
+      if account_already_created toCreate
+      then abort_create_exists senderAddress
+      else proceed_create senderAddress address value code cappedGas
+    od
   od
 End
 


### PR DESCRIPTION
Check the CREATE and CREATE2 balance, nonce, and call-depth failure conditions before adding the prospective contract address to the warm access set. These failures occur before account creation begins and must leave the address, storage domain, and rollback access set unchanged.

Update the affected well-formedness, gas, domain-separation, storage, step-length, jump-destination, context-growth, and RunCall proofs to follow the new control-flow order. Also update `SPEC_Create_fail` to describe the corrected early-abort state while retaining the existing collision and successful-create specifications.

This fixes the EEST insufficient-balance and nonce-overflow cases in indices 0002 and 0003. Both targeted cases pass, and the complete HOL build passes.