### PR TITLE
Clear return data on SELFDESTRUCT

### DIFF
--- a/spec/prop/vfmDecreasesGasScript.sml
+++ b/spec/prop/vfmDecreasesGasScript.sml
@@ -1832,11 +1832,19 @@ Proof
   \\ irule_at Any decreases_gas_update_accounts \\ rw []
   \\ irule_at Any decreases_gas_bind_right
   \\ irule_at Any decreases_gas_get_original \\ simp [] \\ gen_tac
-  \\ irule_at Any decreases_gas_ignore_bind_right \\ reverse (rw [])
-  >- irule_at Any decreases_gas_return
   \\ irule_at Any decreases_gas_ignore_bind_right
-  \\ irule_at Any decreases_gas_update_accounts \\ rw []
-  \\ irule_at Any decreases_gas_add_to_delete
+  \\ conj_tac
+  >- (Cases_on `account_empty (lookup_account x'' x)`
+      >- (simp []
+          \\ irule_at Any decreases_gas_ignore_bind_right
+          \\ irule_at Any decreases_gas_update_accounts \\ rw []
+          \\ irule_at Any decreases_gas_add_to_delete)
+      \\ simp []
+      \\ irule_at Any decreases_gas_return)
+  \\ irule_at Any decreases_gas_ignore_bind_right
+  \\ conj_tac
+  >- irule_at Any decreases_gas_set_return_data
+  \\ irule_at Any decreases_gas_finish
 QED
 
 Theorem decreases_gas_get_current_code[simp]:
@@ -1856,6 +1864,7 @@ Proof
     \\ irule_at Any decreases_gas_set_return_data)
   >- (irule decreases_gas_mono
     \\ irule_at Any decreases_gas_consume_gas \\ rw [])
+  \\ irule decreases_gas_step_self_destruct
 QED
 
 Theorem decreases_gas_cred_step_inner:

--- a/spec/prop/vfmDecreasesGasScript.sml
+++ b/spec/prop/vfmDecreasesGasScript.sml
@@ -1822,6 +1822,8 @@ Proof
   \\ irule_at Any decreases_gas_access_address_bind \\ rw []
   \\ irule_at Any decreases_gas_bind_right
   \\ irule_at Any decreases_gas_get_callee \\ rw []
+  \\ irule_at Any decreases_gas_ignore_bind_right
+  \\ irule_at Any decreases_gas_set_return_data \\ rw []
   \\ irule_at Any decreases_gas_bind_right
   \\ irule_at Any decreases_gas_get_accounts \\ simp [] \\ gen_tac
   \\ irule_at Any decreases_gas_ignore_bind_right
@@ -1832,19 +1834,11 @@ Proof
   \\ irule_at Any decreases_gas_update_accounts \\ rw []
   \\ irule_at Any decreases_gas_bind_right
   \\ irule_at Any decreases_gas_get_original \\ simp [] \\ gen_tac
+  \\ irule_at Any decreases_gas_ignore_bind_right \\ reverse (rw [])
+  >- irule_at Any decreases_gas_return
   \\ irule_at Any decreases_gas_ignore_bind_right
-  \\ conj_tac
-  >- (Cases_on `account_empty (lookup_account x'' x)`
-      >- (simp []
-          \\ irule_at Any decreases_gas_ignore_bind_right
-          \\ irule_at Any decreases_gas_update_accounts \\ rw []
-          \\ irule_at Any decreases_gas_add_to_delete)
-      \\ simp []
-      \\ irule_at Any decreases_gas_return)
-  \\ irule_at Any decreases_gas_ignore_bind_right
-  \\ conj_tac
-  >- irule_at Any decreases_gas_set_return_data
-  \\ irule_at Any decreases_gas_finish
+  \\ irule_at Any decreases_gas_update_accounts \\ rw []
+  \\ irule_at Any decreases_gas_add_to_delete
 QED
 
 Theorem decreases_gas_get_current_code[simp]:

--- a/spec/prop/vfmDomainSeparationScript.sml
+++ b/spec/prop/vfmDomainSeparationScript.sml
@@ -1586,6 +1586,14 @@ Proof
   \\ simp[]
   \\ qx_gen_tac`senderAddress`
   \\ simp[]
+  \\ once_rewrite_tac[ignore_bind_def]
+  \\ irule ignores_extra_domain_imp_pred_bind
+  \\ simp[]
+  \\ reverse conj_tac
+  >- (rw[set_return_data_def, get_current_context_def, bind_def, return_def,
+         fail_def, set_current_context_def]
+      \\ Cases_on`s.contexts` \\ gvs[]
+      \\ Cases_on`h` \\ gvs[])
   \\ simp[SIMP_RULE(srw_ss())[LET_THM, AC ADD_ASSOC ADD_COMM]self_destruct_helper]
   \\ irule get_accounts_ignore_extra_domain_pred_bind
   \\ simp[]
@@ -2482,6 +2490,7 @@ Proof
   Cases_on`op` \\ rw[step_inst_def]
   \\ TRY (irule ignores_extra_domain_pred_imp \\ simp[] \\ tac \\ NO_TAC)
   \\ TRY $ irule step_self_balance_ignore_extra_domain
+  \\ TRY $ irule step_self_destruct_ignores_extra_domain
   \\ TRY $ irule step_create_ignores_extra_domain
   \\ TRY $ irule step_call_ignores_extra_domain
 QED
@@ -3164,6 +3173,7 @@ Proof
   \\ irule preserves_domain_has_callee_bind \\ simp[] \\ gen_tac
   \\ irule preserves_domain_has_callee_bind \\ simp[] \\ gen_tac
   \\ irule preserves_domain_has_callee_bind \\ simp[] \\ gen_tac
+  \\ irule preserves_domain_has_callee_ignore_bind \\ simp[]
   \\ irule preserves_domain_has_callee_bind \\ simp[] \\ gen_tac
   \\ irule preserves_domain_has_callee_ignore_bind \\ simp[]
   \\ irule preserves_domain_has_callee_ignore_bind \\ simp[]
@@ -3617,6 +3627,7 @@ Theorem step_inst_preserves_domain_has_callee[simp]:
 Proof
   Cases_on`op` \\ rw[step_inst_def]
   \\ TRY (irule preserves_domain_has_callee_ignore_bind \\ rw[])
+  \\ TRY (irule preserves_domain_has_callee_step_self_destruct \\ rw[])
   \\ TRY (irule preserves_domain_has_callee_step_create \\ rw[])
   \\ TRY (irule preserves_domain_has_callee_step_copy_to_memory \\ rw[])
 QED

--- a/spec/prop/vfmSameFrameScript.sml
+++ b/spec/prop/vfmSameFrameScript.sml
@@ -2236,6 +2236,7 @@ QED
      pop_stack 1                    -- preserves_same_frame
      access_address address         -- preserves_same_frame
      senderAddress <- get_callee;
+     set_return_data []             -- preserves_same_frame
      accounts <- get_accounts;
      consume_gas ...                -- preserves_same_frame
      assert_not_static              -- preserves_same_frame
@@ -2258,6 +2259,14 @@ Proof
   \\ irule psf_bind >> simp[]
   >> qexists_tac`K (K T)` >> simp[] >> gen_tac
   >> irule psf_bind_get_callee >> simp[] >> qx_gen_tac`callee`
+  >> irule psf_ignore_bind >> simp[]
+  >> qexists_tac`λs. callee = (FST (HD s.contexts)).msgParams.callee ∧
+                         s.contexts ≠ []`
+  >> conj_tac
+  >- (rw[set_return_data_def, get_current_context_def, bind_def, return_def,
+         fail_def, set_current_context_def]
+      >> Cases_on`s.contexts` >> gvs[]
+      >> Cases_on`h` >> gvs[])
   >> irule psf_bind_get_accounts >> simp[] >> qx_gen_tac`accounts`
   \\ irule psf_ignore_bind >> simp[]
   \\ qabbrev_tac`acc = lookup_account callee accounts`

--- a/spec/prop/vfmStoragePredicatesScript.sml
+++ b/spec/prop/vfmStoragePredicatesScript.sml
@@ -669,6 +669,11 @@ Proof
   irule preserves_storage_bind >> simp[] >> gen_tac >>
   irule preserves_storage_bind >> simp[] >> gen_tac >>
   irule preserves_storage_bind >> simp[] >> gen_tac >>
+  irule preserves_storage_ignore_bind >>
+  conj_tac
+  >- (rw[preserves_storage_def, set_return_data_def, get_current_context_def,
+         bind_def, return_def, fail_def, set_current_context_def] >>
+      gvs[AllCaseEqs()]) >>
   simp[preserves_storage_def, bind_def] >> rpt gen_tac >>
   simp[AllCaseEqs()] >> rpt strip_tac >> gvs[get_accounts_def, return_def] >>
   rename1`consume_gas n` >>

--- a/spec/vfmExecutionScript.sml
+++ b/spec/vfmExecutionScript.sml
@@ -1041,6 +1041,7 @@ Definition step_self_destruct_def:
     address <<- w2w $ EL 0 args;
     accessCost <- access_address address;
     senderAddress <- get_callee;
+    set_return_data [];
     accounts <- get_accounts;
     sender <<- lookup_account senderAddress accounts;
     balance <<- sender.balance;
@@ -1057,7 +1058,6 @@ Definition step_self_destruct_def:
         update_account senderAddress (sender with balance := 0);
       add_to_delete senderAddress
     od else return ();
-    set_return_data [];
     finish
   od
 End

--- a/spec/vfmExecutionScript.sml
+++ b/spec/vfmExecutionScript.sml
@@ -1057,6 +1057,7 @@ Definition step_self_destruct_def:
         update_account senderAddress (sender with balance := 0);
       add_to_delete senderAddress
     od else return ();
+    set_return_data [];
     finish
   od
 End


### PR DESCRIPTION
Clear the current frame's return-data buffer before SELFDESTRUCT finishes so a successful call cannot expose stale output from an earlier nested call. This matches the empty output produced by SELFDESTRUCT and fixes EEST case 0032.

Update the gas-decrease proofs to account for the added return-data operation and handle the SELFDESTRUCT instruction case explicitly.